### PR TITLE
Enable ISO9660 to be subclassed with an overridden get_sector method

### DIFF
--- a/iso9660.py
+++ b/iso9660.py
@@ -23,7 +23,8 @@ class ISO9660(object):
         self._paths = []   #path table
 
         self._url   = url
-        self._get_sector = self._get_sector_url if url.startswith('http') else self._get_sector_file
+        if self._get_sector is None: #it might have been set by a subclass
+            self._get_sector = self._get_sector_url if url.startswith('http') else self._get_sector_file
 
         ### Volume Descriptors
         sector = 0x10


### PR DESCRIPTION
I need to subclass ISO9660 to support retrieving the sectors from the file using another method.  This pull request includes two small changes to make this possible/easier:
1. 74c7538 provides a constant for the sector size so that the subclass can reference this instead of having to use the magic number "2048".
2. 74c7538 allows the _get_sector member to be overridden by subclasses.

Thanks for providing this code!
